### PR TITLE
Fixed incorrect skill amounts being written to journal

### DIFF
--- a/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal XP.lua
+++ b/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal XP.lua
@@ -115,15 +115,15 @@ local function catchJavaAddXP(player, perksType, XP)
 
     local debugPrint = "passUnBoostOnAddXP: "
     ---checking if it's 'not false' instead of 'true' because I want older saves before this sandbox option to get what they expect to occur
-    if SandboxVars.SkillRecoveryJournal.RecoverProfessionAndTraitsBonuses == false then
+    if SandboxVars.SkillRecoveryJournal.RecoverProfessionAndTraitsBonuses ~= false then
         local xpBoostID = pXP:getPerkBoost(perksType)
         local xpBoostDenominator = 1
 
-        if xpBoostID == 0 and (not isSkillExcludedFrom.SpeedReduction(perksType)) then xpBoostDenominator = 1 -- Assumes 0.25 is the 'base' XP rate
-        elseif xpBoostID == 1 and perksType==Perks.Sprinting then xpBoostDenominator = 0.20 -- reciprocal of 1.25 (1 1/4 == 5/4), equivalent to a 125.00% XP rate, 500% relative XP gain; (1.25 is specific to sprinting skill, otherwise evaluate to next statement)
-        elseif xpBoostID == 1 then xpBoostDenominator = 0.25 -- reciprocal of 4 (4/1), equivalent to a 100.00% XP rate, 400% relative XP gain
-        elseif xpBoostID == 2 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostDenominator = 0.1875 -- reciprocal of 5.33 (5 1/3 == 16/3), equivalent to a 133.33% XP rate, 533% relative XP gain
-        elseif xpBoostID == 3 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostDenominator = 0.15 -- reciprocal or 6.67 (6 2/3 == 20/3), equivalent to a 166.67% XP rate, 667% relative XP gain
+        if xpBoostID == 0 and (not isSkillExcludedFrom.SpeedReduction(perksType)) then xpBoostDenominator = 1 -- Assumes 0.25 is the 'base' XP rate (i.e. x / 1 = x)
+        elseif xpBoostID == 1 and perksType==Perks.Sprinting then xpBoostDenominator = 0.80 -- reciprocal of (1.25 == 1 1/4 == 5/4) is (4/5 == 0.80), equivalent to a 125.00% XP rate, 500% relative XP gain; (1.25 is specific to sprinting skill, otherwise evaluate to next statement)
+        elseif xpBoostID == 1 then xpBoostDenominator = 0.25 -- reciprocal of (4 == 4/1) is (1/4 == 0.25), equivalent to a 100.00% XP rate, 400% relative XP gain
+        elseif xpBoostID == 2 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostDenominator = 0.1875 -- reciprocal of (5.33 == 5 1/3 == 16/3) is (3/16 == 0.1875), equivalent to a 133.33% XP rate, 533% relative XP gain
+        elseif xpBoostID == 3 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostDenominator = 0.15 -- reciprocal or (6.67 == 6 2/3 == 20/3) is (3/20 == 0.15), equivalent to a 166.67% XP rate, 667% relative XP gain
         end
         if getDebug() then debugPrint = debugPrint..XP.."/"..xpBoostDenominator end
         XP = XP/xpBoostDenominator

--- a/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal XP.lua
+++ b/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal XP.lua
@@ -117,16 +117,16 @@ local function catchJavaAddXP(player, perksType, XP)
     ---checking if it's 'not false' instead of 'true' because I want older saves before this sandbox option to get what they expect to occur
     if SandboxVars.SkillRecoveryJournal.RecoverProfessionAndTraitsBonuses == false then
         local xpBoostID = pXP:getPerkBoost(perksType)
-        local xpBoostNumerator = 1
+        local xpBoostDenominator = 1
 
-        if xpBoostID == 0 and (not isSkillExcludedFrom.SpeedReduction(perksType)) then xpBoostNumerator = 0.25
-        elseif xpBoostID == 1 and perksType==Perks.Sprinting then xpBoostNumerator = 1.25
-        elseif xpBoostID == 1 then xpBoostNumerator = 1
-        elseif xpBoostID == 2 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostNumerator = 1.33
-        elseif xpBoostID == 3 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostNumerator = 1.66
+        if xpBoostID == 0 and (not isSkillExcludedFrom.SpeedReduction(perksType)) then xpBoostDenominator = 1 -- Assumes 0.25 is the 'base' XP rate
+        elseif xpBoostID == 1 and perksType==Perks.Sprinting then xpBoostDenominator = 0.20 -- reciprocal of 1.25 (1 1/4 == 5/4), equivalent to a 125.00% XP rate, 500% relative XP gain; (1.25 is specific to sprinting skill, otherwise evaluate to next statement)
+        elseif xpBoostID == 1 then xpBoostDenominator = 0.25 -- reciprocal of 4 (4/1), equivalent to a 100.00% XP rate, 400% relative XP gain
+        elseif xpBoostID == 2 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostDenominator = 0.1875 -- reciprocal of 5.33 (5 1/3 == 16/3), equivalent to a 133.33% XP rate, 533% relative XP gain
+        elseif xpBoostID == 3 and (not isSkillExcludedFrom.SpeedIncrease(perksType)) then xpBoostDenominator = 0.15 -- reciprocal or 6.67 (6 2/3 == 20/3), equivalent to a 166.67% XP rate, 667% relative XP gain
         end
-        if getDebug() then debugPrint = debugPrint..XP.."/"..xpBoostNumerator end
-        XP = XP/xpBoostNumerator
+        if getDebug() then debugPrint = debugPrint..XP.."/"..xpBoostDenominator end
+        XP = XP/xpBoostDenominator
     end
 
     if currentXP <= maxLevelXP then


### PR DESCRIPTION
The issue appears to stem from copying over the similar if-block from the unBlock function. Instead of multiplying like in unBlock, the code in catchJavaAddXP uses division, and the numbers were not modified to account for that. The variable xpBoostNumerator was also being used as the divisor, so I renamed it appropriately to 'denominator'. Left some robust comments to help potential readers understand the math as well.

Testing:
I did some very rudimentary testing with an unemployed, trait-less character. Did a couple tasks to give some quick exp to the sneak, lightfood, and cooking skills as they seemed to be the most common skills affected. Spawned a journal, transcribed it, and the values in the journal matched exactly what I would expect. The attached console log also corroborates this.

[17-12-23_13-33-24_DebugLog.txt](https://github.com/Chuckleberry-Finn/Skill-Recovery-Journal/files/13697700/17-12-23_13-33-24_DebugLog.txt)